### PR TITLE
Depend on a version of angular-stamplay compatible w/jssdk v1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "angular": "~1.4.8",
     "angular-ui-router": "~0.2.15",
     "stamplay-js-sdk": "~1.3.3",
-    "angular-stamplay": "*",
+    "angular-stamplay": "313f9d1c98284020bba8d5bab75224b02394f10b",
     "bootstrap": "~3.3.6",
     "angular-bootstrap": "~0.14.3",
     "Bootflat": "~2.0.4"


### PR DESCRIPTION
This project is currently not compatible with stamplay-js-sdk v2 (see #1)... in the meantime, make it working with v1 :-)
I think that latest (v0.0.2) version of angular-stamplay has been adapted for js-sdk v2, so use a prior version.